### PR TITLE
Return 401 status code for failed authorizer

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,13 @@ const lib = require('./lib');
 let data;
 
 // Lambda function index.handler - thin wrapper around lib.authenticate
-module.exports.handler = async (event) => {
+module.exports.handler = async (event, context, callback) => {
   try {
     data = await lib.authenticate(event);
   }
   catch (err) {
       console.log(err);
-      return `Unauthorized: ${err.message}`;
+      return context.fail("Unauthorized");
   }
   return data;
 };


### PR DESCRIPTION
Currently the when the custom authorizer fails, the response to the request is:

```
Status: 500

{
  "message": null
}
```

This PR leverages the `context.fail("Unauthorized")` function call to return:

```
Status: 401

{
  "message": "Unauthorized"
}
```

Note that the message cannot be changed, for example including any other text in the `context.fail` call results in a `500` response. The only documentation I've found of this was in this thread https://forums.aws.amazon.com/thread.jspa?threadID=226689. 

So while this is still not ideal, I think always returning a `401` is an improvement over returning a `500`.

It could be useful to document somewhere that for testing purposes returning 

```
return `Unauthorized: ${err.message}`;
```

can be useful because the `err.message` is surfaced using the Test events in the AWS Lambda configuration screen. But for production purposes, those messages are not visible to the api caller, so the `401` result is preferred. I'd be happy to include this as a comment, or update the README, whatever you prefer.