### PR TITLE
Global client

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -40,6 +40,13 @@ const jwtOptions = {
     issuer: process.env.TOKEN_ISSUER
 };
 
+const client = jwksClient({
+    cache: true,
+    rateLimit: true,
+    jwksRequestsPerMinute: 10, // Default value
+    jwksUri: process.env.JWKS_URI
+});
+
 module.exports.authenticate = (params) => {
     console.log(params);
     const token = getToken(params);
@@ -48,13 +55,6 @@ module.exports.authenticate = (params) => {
     if (!decoded || !decoded.header || !decoded.header.kid) {
         throw new Error('invalid token');
     }
-
-    const client = jwksClient({
-        cache: true,
-        rateLimit: true,
-        jwksRequestsPerMinute: 10, // Default value
-        jwksUri: process.env.JWKS_URI
-    });
 
     const getSigningKey = util.promisify(client.getSigningKey);
     return getSigningKey(decoded.header.kid)


### PR DESCRIPTION
Both `cache` and `rateLimit` options are worthless if the client is recreated for each lambda execution.

Due to the stateless nature of lambda functions, this is not able to ensure proper caching, but at least on hot starts the client will be reused for each lambda container which is better than nothing.

Am I missing anything? Is the client cache somehow working even when recreated each time?