### PR TITLE
Generate generic method policy for API Gateway

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -4,7 +4,14 @@ const jwksClient = require('jwks-rsa');
 const jwt = require('jsonwebtoken');
 const util = require('util');
 
-const getPolicyDocument = (effect, resource) => {
+const getPolicyDocument = (effect, methodArn) => {
+
+    // parse the ARN from the incoming resource
+    var methodArnComponents = methodArn.split(':');
+    var apiOptions = methodArnComponents[5].split('/');
+    methodArnComponents[5] = [apiOptions[0], apiOptions[1], "*"].join('/');
+    var resource = methodArnComponents.join(':');
+
     const policyDocument = {
         Version: '2012-10-17', // default version
         Statement: [{


### PR DESCRIPTION
This pull requests allows the authorizer to be cached and reused with different methods. Perhaps it would be good to add some sort of configuration and document such feature.

Per API Gateway documentation (https://docs.aws.amazon.com/apigateway/latest/developerguide/configure-api-gateway-lambda-authorization-with-console.html):
>...
>Note
>To enable caching, your authorizer must return a policy that is applicable to all methods across an API. To enforce method-specific policy, you can set the TTL value to zero to disable policy caching for the API.
>...