### PR TITLE
Updated Package.json to fix bundle command for more environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "lambda-local --timeout 300 --lambda-path index.js --event-path event.json",
-    "bundle": "rm -f custom-authorizer.zip ; zip custom-authorizer.zip -r *.js *.json node_modules/"
+    "bundle": "rm -f custom-authorizer.zip && zip custom-authorizer.zip -r *.js *.json node_modules/"
   },
   "author": "Jason Haines",
   "license": "Apache-2.0",


### PR DESCRIPTION
Changed ; to && because gitbash fails to parse the semicolon.