### PR TITLE
update license info in README.md to match LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,4 +336,4 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## License
 
-This project is licensed under the MIT license. See the [LICENSE](LICENSE.txt) file for more info.
+This project is licensed under the Apache License (Version 2.0). See the [LICENSE](LICENSE) file for more info.


### PR DESCRIPTION
`README.md` states software is licensed under MIT license, but `LICENSE` file is Apache V2. Also, `README.md` links to `LICENSE.txt`, but the correct file name is `LICENSE`